### PR TITLE
Add optional initialization step to groupBy

### DIFF
--- a/src/IterationTraits.php
+++ b/src/IterationTraits.php
@@ -226,7 +226,7 @@ class IterationTraits {
      *
      * @param Iterator $iterator
      * @param callable $fnToGroup
-     * @param null $keys
+     * @param null|int|array $keys -- Defines the array which values are grouped into. @see IterationTraits::initKeysForGroupBy()
      * @return Sequence
      */
     public static function groupBy(Iterator $iterator, $fnToGroup, $keys = null) {
@@ -245,7 +245,7 @@ class IterationTraits {
      *
      * If $keys is...
      *  null  -> empty array; no nested arrays (default)
-     *  int   -> indexed array with length = $keys
+     *  int   -> indexed array with length = $keys and indices 0 to $keys-1
      *  array -> associative array keyed by the values of $keys
      *
      * @param null|int|array $keys

--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -205,10 +205,11 @@ class Sequence extends IteratorIterator implements IterationFunctions, Recursive
      * Group A Sequence based upon the result of $fnMapValueToGroup($value, $key) and return the result as a Sequence
      *
      * @param $fnMapValueToGroup($value, $key) -- return the field name to group the values under.
+     * @param null|int|array $keys -- Defines the array which values are grouped into. @see IterationTraits::initKeysForGroupBy()
      * @return static
      */
-    public function groupBy($fnMapValueToGroup) {
-        return static::make(IterationTraits::groupBy($this, $fnMapValueToGroup));
+    public function groupBy($fnMapValueToGroup, $keys = null) {
+        return static::make(IterationTraits::groupBy($this, $fnMapValueToGroup, $keys));
     }
 
     /**


### PR DESCRIPTION
I found that using groupBy can require some extra steps if you don't have a predefined set of keys for it to be grouped on, especially if some of the keys can be empty. I intended this change to help with that by providing a simple way to generate an initial grouping. What do you think?